### PR TITLE
Docker: mat inn secrets/repo + diverse

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,8 +27,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-      GITHUB_PAT: ${{ secrets.GT }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_COMPILE_AND_INSTALL_PACKAGES: never
 
     steps:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
       R_COMPILE_AND_INSTALL_PACKAGES: never
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -47,7 +47,5 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--as-cran")'
           error-on: '"error"'
-          check-dir: '"check"'
-          upload-snapshots: true
+          args: c("--no-manual") # Avoid "--as-cran"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -21,18 +21,14 @@ jobs:
         IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: "Dockerfile"
-      - name: R setup
-        uses: r-lib/actions/setup-r@v2
-      - name: Build package (tarball)
-        run: R CMD build .
       - name: Prepare tags
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           flavor: |
@@ -42,17 +38,19 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Harbor
         if: github.event_name == 'release'
         run: |
           echo ${{ secrets.HARBOR_PASSWORD }} | docker login --username ${{ secrets.HARBOR_USERNAME }} --password-stdin ${{ secrets.HARBOR_REGISTRY }}
       - name: Build image and push to Harbor
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           tags: ${{ secrets.HARBOR_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
           push: ${{ github.event_name == 'release' }}
+          pull: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: "github_pat=${{ secrets.GITHUB_TOKEN }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM rapporteket/base-r:main
 
-LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
-LABEL no.rapporteket.cd.enable="true"
-
 WORKDIR /app/R
 
-COPY *.tar.gz .
-
-RUN R -e "remotes::install_local(list.files(pattern = \"*.tar.gz\"))" \
-    && rm ./*.tar.gz \
+RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
+    --mount=type=bind,source=.,target=/app/R/pkg \
+    R -e "remotes::install_local(path = './pkg')" \
     && R -e "remotes::install_github(\"Rapporteket/rapbase\", ref = \"main\")"
 
 EXPOSE 3838


### PR DESCRIPTION
- Matet inn secrets, slik at de ikke være synlig i bygg etterpå.
- Matet inn repo og bygde pakken inne i Dockerfile. Det betyr at det ikke lenger er nødvendig å bygge en tar.gz-fil utenfor før man bygger image. Da slipper man å sette opp R-miljø i action.
- Byttet i tillegg til GITHUB_TOKEN, som kun finnes midlertidig mens jobb kjører.
- Oppdatert også actions-jobber med diverse små-endringer. 
- Prøvd å gjøre jobbene kjappere ved å bruke ferdig-installerte pakker.